### PR TITLE
Example solution 1 (DO NOT MERGE)

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -4,14 +4,26 @@ const router = express.Router()
 const USERNAME = 'Demo User'
 const USEREMAIL = 'demo@example.com'
 const USERPASSWORD = 'demo1234'
+const USERPASSWORD2 = 'betterPassword3!Q5'
 
 router.post('/', function (req, res, next) {
   // console.log('User credentials:', req.body.email)
 
-  if (req.body.email === USEREMAIL && req.body.password === USERPASSWORD) {
+  // For this exercise, we will allow either password to log in
+  if (req.body.email === USEREMAIL && (req.body.password === USERPASSWORD || req.body.password === USERPASSWORD2)) {
     req.session.username = USERNAME
     req.session.lastLogin = Date.now()
-    res.redirect('/users/welcome')
+
+    if (req.body.password.length < 10) {
+      // If the user's password is too short, render the welcome page, but show a warning
+      res.render('users/welcome', {
+        title: 'Security Alert',
+        warningMsg: 'Your password is too short, please change it to protect your account'
+      })
+    } else {
+      // Otherwise redirect to the welcome page as before
+      res.redirect('/users/welcome')
+    }
   } else {
     res.redirect('/?msg=invalid_credentials')
   }

--- a/test/users.js
+++ b/test/users.js
@@ -2,10 +2,20 @@ const request = require('supertest')
 const app = require('../app')
 
 describe('POST /users', function () {
-  it('log in with username and password', function (done) {
+  it('warns user that password is too short', function (done) {
+    // We expect login with a short password to display a warning
     request.agent(app)
       .post('/users')
       .send({ email: 'demo@example.com', password: 'demo1234' })
+      .redirects(5)
+      .expect(200, /Your password is too short/, done)
+  })
+
+  it('log in with username and password', function (done) {
+    // We expect login with a good password to redirect to the welcome page
+    request.agent(app)
+      .post('/users')
+      .send({ email: 'demo@example.com', password: 'betterPassword3!Q5' })
       .redirects(5)
       .expect(200, /Welcome back/, done)
   })

--- a/views/users/welcome.ejs
+++ b/views/users/welcome.ejs
@@ -7,6 +7,9 @@
       <p>
         <%= title %>
       </p>
+      <% if (typeof warningMsg != "undefined") { %>
+        <div class="alert alert-danger" role="alert"><%= warningMsg %></div>
+      <% } %>
       <p><a href="/users/logout">&raquo; Log out now</a></p>
     </div>
   </div>


### PR DESCRIPTION
This is a reference solution for facilitators.

If the password is too short on login, instead of redirecting, it renders the welcome page immediately, with a warning.

This is slightly easier to achieve, because it avoids passing messages through the redirect.

(Redirect and message passing may be confusing for participants. On the other hand, it is good practice to redirect after a POST.)